### PR TITLE
Adapted for H2 1.4.200

### DIFF
--- a/benchmarks/bms/h2/h2.cnf
+++ b/benchmarks/bms/h2/h2.cnf
@@ -6,8 +6,7 @@ benchmark h2
 size small args 
 		"--total-transactions", "400",
 		"--scale","2",
-		"--cleanup-in-iteration",
-		"--create-suffix", ";MVCC=true"
+		"--cleanup-in-iteration"
   thread-limit 400
   output stdout digest 0x9e2c93be488a4dab37923989b7df8cd029f8bb09,
          stderr digest 0xda39a3ee5e6b4b0d3255bfef95601890afd80709;
@@ -15,8 +14,7 @@ size small args
 size default args
 		"--total-transactions","4000",
 		"--scale","8",
-		"--cleanup-in-iteration",
-		"--create-suffix", ";MVCC=true"
+		"--cleanup-in-iteration"
   thread-limit 4000
   output stdout digest 0x479c676628ca31f3364af094d392f86183bbf8cd,
          stderr digest 0xda39a3ee5e6b4b0d3255bfef95601890afd80709;
@@ -24,8 +22,7 @@ size default args
 size large args 
 		"--total-transactions","32000",
 		"--scale","8",
-		"--cleanup-in-iteration",
-		"--create-suffix", ";MVCC=true"
+		"--cleanup-in-iteration"
   thread-limit 64000
   output stdout digest 0xe095f0c0da08af9e7419a7c1e30db59a0e11cb15,
          stderr digest 0xda39a3ee5e6b4b0d3255bfef95601890afd80709;
@@ -33,8 +30,7 @@ size large args
 size huge args 
 		"--total-transactions","256000",
 		"--scale","32",
-		"--cleanup-in-iteration",
-		"--create-suffix", ";MVCC=true"
+		"--cleanup-in-iteration"
   thread-limit 256000
   output stdout digest 0xe4154dca4e8f2d9d34f659524220c50b0b498310,
          stderr digest 0xda39a3ee5e6b4b0d3255bfef95601890afd80709;

--- a/benchmarks/bms/h2/src/org/dacapo/h2/TPCC.java
+++ b/benchmarks/bms/h2/src/org/dacapo/h2/TPCC.java
@@ -303,6 +303,10 @@ public class TPCC {
         e.printStackTrace();
       }
     }
+    // Without COMMIT this connection does not see changes made by other connections
+    // This is probably related to transaction isolation with MVStore
+    // https://github.com/h2database/h2database/releases/tag/version-1.4.200
+    getConnection().commit();
     // done running the submitters
 
     System.out.println();

--- a/benchmarks/libs/derby/derby.patch
+++ b/benchmarks/libs/derby/derby.patch
@@ -232,13 +232,16 @@ diff -urNw derby-b/db-derby-10.5.3.0-src/java/testing/org/apache/derbyTesting/sy
 -                + "C_PAYMENT_CNT, C_DELIVERY_CNT, C_DATA)  "
 +                + "C_PAYMENT_CNT, C_DELIVERY_CNT, C_DATA, C_DATA_INITIAL)  "
                  + "VALUES (?, ?, ?, ?, 'OE', ?, ?, ?, ?, ?, ?, ?, "
-                 + " CURRENT TIMESTAMP ,?, 50000.00, ?, -10.0, 10.0,"
+-                + " CURRENT TIMESTAMP ,?, 50000.00, ?, -10.0, 10.0,"
 -                + " 1, 0, ?)");
+# Does not work without underscore since 1.4.198. http://www.h2database.com/html/functions.html#current_timestamp
++                + " CURRENT_TIMESTAMP ,?, 50000.00, ?, -10.0, 10.0,"
 +                + " 1, 0, ?, ?)");
  
          PreparedStatement psH = conn
 -                .prepareStatement("INSERT INTO HISTORY (H_C_ID, H_C_D_ID, H_C_W_ID, H_D_ID, H_W_ID, H_DATE, H_AMOUNT, H_DATA) VALUES (?, ?, ?, ?, ?, CURRENT TIMESTAMP, 10.00, ?)");
-+                .prepareStatement("INSERT INTO HISTORY (H_C_ID, H_C_D_ID, H_C_W_ID, H_D_ID, H_W_ID, H_DATE, H_AMOUNT, H_DATA, H_INITIAL) VALUES (?, ?, ?, ?, ?, CURRENT TIMESTAMP, 10.00, ?, TRUE)");
+# Does not work without underscore since 1.4.198. http://www.h2database.com/html/functions.html#current_timestamp
++                .prepareStatement("INSERT INTO HISTORY (H_C_ID, H_C_D_ID, H_C_W_ID, H_D_ID, H_W_ID, H_DATE, H_AMOUNT, H_DATA, H_INITIAL) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, 10.00, ?, TRUE)");
  
          psC.setShort(2, d); // c_d_id
          psC.setShort(3, w); // c_w_id


### PR DESCRIPTION
This PR adapts the H2 benchmark code base for H2 1.4.200. It does not update the version from 1.4.196 (current) to 1.4.200 but makes it possible to do it.

**Changes**

1. In 1.4.198 SQL expression  `CURRENT TIMESTAMP` no longer works and had to be replaced with `CURRENT_TIMESTAMP`. [Reference](http://www.h2database.com/html/functions.html#current_timestamp).
2. In 1.4.200 The MVCC setting was removed because the default database engine (MVStore) is multi-threaded by default since 1.4.198. I added a `COMMIT` statement after all submitters finish, this is required because of the changes in H2 transaction isolation. [H2 Release notes](https://github.com/h2database/h2database/releases/tag/version-1.4.200)